### PR TITLE
Feature/entity/domains 

### DIFF
--- a/src/main/java/com/example/extra/ExtraApplication.java
+++ b/src/main/java/com/example/extra/ExtraApplication.java
@@ -2,7 +2,9 @@ package com.example.extra;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ExtraApplication {
 

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
@@ -1,0 +1,47 @@
+package com.example.extra.domain.applicationrequest.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import com.example.extra.global.enums.ApplyStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_APPLICATION_REQUEST_COMPANY")
+@Entity
+public class ApplicationRequestCompany extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private ApplyStatus applyStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Builder
+    public ApplicationRequestCompany(
+        ApplyStatus applyStatus,
+        Member member,
+        Role role
+    ){
+        this.applyStatus = applyStatus;
+        this.member = member;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
@@ -2,11 +2,13 @@ package com.example.extra.domain.applicationrequest.entity;
 
 import com.example.extra.global.common.BaseEntity;
 import com.example.extra.global.enums.ApplyStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,13 +19,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_APPLICATION_REQUEST_COMPANY")
+@Table(name = "TB_APPLICATION_REQUEST_COMPANY",
+    indexes = {
+        @Index(columnList = "createdAt")
+    }
+)
 @Entity
 public class ApplicationRequestCompany extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "apply_status", nullable = false)
     private ApplyStatus applyStatus;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestCompany.java
@@ -2,13 +2,11 @@ package com.example.extra.domain.applicationrequest.entity;
 
 import com.example.extra.global.common.BaseEntity;
 import com.example.extra.global.enums.ApplyStatus;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,18 +17,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_APPLICATION_REQUEST_COMPANY",
-    indexes = {
-        @Index(columnList = "createdAt")
-    }
-)
+@Table(name = "TB_APPLICATION_REQUEST_COMPANY")
 @Entity
 public class ApplicationRequestCompany extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "apply_status", nullable = false)
     private ApplyStatus applyStatus;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
@@ -2,13 +2,11 @@ package com.example.extra.domain.applicationrequest.entity;
 
 import com.example.extra.global.common.BaseEntity;
 import com.example.extra.global.enums.ApplyStatus;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,18 +17,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_APPLICATION_REQUEST_MEMBER",
-    indexes = {
-        @Index(columnList = "createdAt")
-    }
-)
+@Table(name = "TB_APPLICATION_REQUEST_MEMBER")
 @Entity
 public class ApplicationRequestMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "apply_status", nullable = false)
     private ApplyStatus applyStatus;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
@@ -1,0 +1,47 @@
+package com.example.extra.domain.applicationrequest.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import com.example.extra.global.enums.ApplyStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_APPLICATION_REQUEST_MEMBER")
+@Entity
+public class ApplicationRequestMember extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private ApplyStatus applyStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Builder
+    public ApplicationRequestMember(
+        ApplyStatus applyStatus,
+        Member member,
+        Role role
+    ){
+        this.applyStatus = applyStatus;
+        this.member = member;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequestMember.java
@@ -2,11 +2,13 @@ package com.example.extra.domain.applicationrequest.entity;
 
 import com.example.extra.global.common.BaseEntity;
 import com.example.extra.global.enums.ApplyStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,13 +19,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_APPLICATION_REQUEST_MEMBER")
+@Table(name = "TB_APPLICATION_REQUEST_MEMBER",
+    indexes = {
+        @Index(columnList = "createdAt")
+    }
+)
 @Entity
 public class ApplicationRequestMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "apply_status", nullable = false)
     private ApplyStatus applyStatus;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
+++ b/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
@@ -1,0 +1,68 @@
+package com.example.extra.domain.attendancemanagement.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_ATTENDANCE_MANAGEMENT")
+@Entity
+public class AttendanceManagement extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime clockInTime;
+
+    private LocalDateTime clockOutTime;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean breakfast;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean lunch;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean dinner;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "job_post_id")
+    private JobPost jobPost;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public AttendanceManagement(
+        LocalDateTime clockInTime,
+        LocalDateTime clockOutTime,
+        Boolean breakfast,
+        Boolean lunch,
+        Boolean dinner,
+        JobPost jobPost,
+        Member member
+    ){
+        this.clockInTime = clockInTime;
+        this.clockOutTime = clockOutTime;
+        this.breakfast = breakfast;
+        this.lunch = lunch;
+        this.dinner = dinner;
+        this.jobPost = jobPost;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
+++ b/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
@@ -26,8 +26,10 @@ public class AttendanceManagement extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "clock_in_time")
     private LocalDateTime clockInTime;
 
+    @Column(name = "clock_out_time")
     private LocalDateTime clockOutTime;
 
     @Column(columnDefinition = "boolean default false")

--- a/src/main/java/com/example/extra/domain/company/entity/Company.java
+++ b/src/main/java/com/example/extra/domain/company/entity/Company.java
@@ -2,6 +2,7 @@ package com.example.extra.domain.company.entity;
 
 import com.example.extra.global.common.BaseEntity;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,6 +35,7 @@ public class Company extends BaseEntity {
     @NotNull
     private String name;
 
+    @Column(name = "company_url")
     private String companyUrl;
 
     // TODO - 회사-공고글 양방향 매핑할 지 확인 받기 + cascade 정책 확인 받기

--- a/src/main/java/com/example/extra/domain/company/entity/Company.java
+++ b/src/main/java/com/example/extra/domain/company/entity/Company.java
@@ -1,0 +1,58 @@
+package com.example.extra.domain.company.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_COMPANY")
+@Entity
+public class Company extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String email;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private String name;
+
+    private String companyUrl;
+
+    // TODO - 회사-공고글 양방향 매핑할 지 확인 받기 + cascade 정책 확인 받기
+    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL)
+    private List<JobPost> jobPostList = new ArrayList<>();
+
+    // TODO - 코드 컨벤션(엔티티에 수정 로직 작성x) 지키면서 어떻게 양방향 처리 할 수 있을지 확인하기.
+    // public void addJobPost(JobPost jobPost) {}
+
+    @Builder
+    public Company(
+        String email,
+        String password,
+        String name,
+        String companyUrl
+    ){
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.companyUrl = companyUrl;
+    }
+}

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -7,7 +7,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,23 +18,17 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_COSTUME_APPROVAL_BOARD",
-    indexes = {
-    @Index(columnList = "createdAt"),
-    @Index(columnList = "modifiedAt")
-}
-)
+@Table(name = "TB_COSTUME_APPROVAL_BOARD")
 @Entity
 public class CostumeApprovalBoard extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "costume_approve", columnDefinition = "boolean default false")
+    @Column(columnDefinition = "boolean default false")
     private Boolean costumeApprove;
 
-    // TODO - DTO에 @NotBlank constraint 붙이기.
-    @Column(name = "costume_image_url", nullable = false)
+    @NotNull
     private String costumeImageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -1,0 +1,54 @@
+package com.example.extra.domain.costumeapprovalboard.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_COSTUME_APPROVAL_BOARD")
+@Entity
+public class CostumeApprovalBoard extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean costumeApprove;
+
+    @NotNull
+    private String costumeImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @Builder
+    public CostumeApprovalBoard(
+        Boolean costumeApprove,
+        String costumeImageUrl,
+        Member member,
+        Role role
+    ){
+        this.costumeApprove = costumeApprove;
+        this.costumeImageUrl = costumeImageUrl;
+        this.member = member;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -18,17 +19,23 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "TB_COSTUME_APPROVAL_BOARD")
+@Table(name = "TB_COSTUME_APPROVAL_BOARD",
+    indexes = {
+    @Index(columnList = "createdAt"),
+    @Index(columnList = "modifiedAt")
+}
+)
 @Entity
 public class CostumeApprovalBoard extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "boolean default false")
+    @Column(name = "costume_approve", columnDefinition = "boolean default false")
     private Boolean costumeApprove;
 
-    @NotNull
+    // TODO - DTO에 @NotBlank constraint 붙이기.
+    @Column(name = "costume_image_url", nullable = false)
     private String costumeImageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/memberterms/entity/MemberTerms.java
+++ b/src/main/java/com/example/extra/domain/memberterms/entity/MemberTerms.java
@@ -1,0 +1,49 @@
+package com.example.extra.domain.memberterms.entity;
+
+import com.example.extra.domain.terms.entity.Terms;
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_MEMBER_TERMS")
+@Entity
+public class MemberTerms extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "boolean default true")
+    private Boolean agree;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "term_id")
+    private Terms term;
+
+    @Builder
+    public MemberTerms(
+        Boolean agree,
+        Member member,
+        Terms term
+    ){
+        this.agree = agree;
+        this.member = member;
+        this.term = term;
+    }
+}

--- a/src/main/java/com/example/extra/domain/tattoo/entity/Tattoo.java
+++ b/src/main/java/com/example/extra/domain/tattoo/entity/Tattoo.java
@@ -1,0 +1,80 @@
+package com.example.extra.domain.tattoo.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_TATTOO")
+@Entity
+public class Tattoo extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean face;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean chest;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean arm;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean leg;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean shoulder;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean back;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean hand;
+
+    @Column(columnDefinition = "boolean default false")
+    private Boolean feet;
+
+    private String etc;
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Tattoo(
+        Boolean face,
+        Boolean chest,
+        Boolean arm,
+        Boolean leg,
+        Boolean shoulder,
+        Boolean back,
+        Boolean hand,
+        Boolean feet,
+        String etc,
+        Member member
+    ){
+        this.face = face;
+        this.chest = chest;
+        this.arm = arm;
+        this.leg = leg;
+        this.shoulder = shoulder;
+        this.back = back;
+        this.hand = hand;
+        this.feet = feet;
+        this.etc = etc;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/example/extra/domain/terms/entity/Terms.java
+++ b/src/main/java/com/example/extra/domain/terms/entity/Terms.java
@@ -29,7 +29,6 @@ public class Terms extends BaseEntity {
 
     private Boolean optional;
 
-    // 양방향 매핑 필요 없어 보여서 반영 안함
     @Builder
     public Terms(
         String title,

--- a/src/main/java/com/example/extra/domain/terms/entity/Terms.java
+++ b/src/main/java/com/example/extra/domain/terms/entity/Terms.java
@@ -1,0 +1,43 @@
+package com.example.extra.domain.terms.entity;
+
+import com.example.extra.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "TB_TERMS")
+@Entity
+public class Terms extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+
+    private Boolean optional;
+
+    // 양방향 매핑 필요 없어 보여서 반영 안함
+    @Builder
+    public Terms(
+        String title,
+        String content,
+        Boolean optional
+    ){
+        this.title = title;
+        this.content = content;
+        this.optional = optional;
+    }
+}

--- a/src/main/java/com/example/extra/global/common/BaseEntity.java
+++ b/src/main/java/com/example/extra/global/common/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.example.extra.global.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/extra/global/enums/ApplyStatus.java
+++ b/src/main/java/com/example/extra/global/enums/ApplyStatus.java
@@ -1,0 +1,7 @@
+package com.example.extra.global.enums;
+
+public enum ApplyStatus {
+    APPLIED, // 승인대기
+    REJECTED, // 미승인
+    APPROVED // 승인완료
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- this closes #5

## 📝작업 내용
- erd cloud에 지원 요청 테이블을 support_request에서 application_request로 본래 의미에 맞게 수정
- base entity 작성
- entity 작성
- ApplyStatus enum 작성

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/7af3fe55-d181-4d74-a868-43219390c676)

## 💬리뷰 요구사항(선택)
- Company 엔티티에서 JOB_POST로 양방향 매핑할 지의 여부를 정해주시면 좋겠습니다.
   - 양방향 매핑을 한다면 cascade 정책은 어떻게 할지 
   - 코드 컨벤션(엔티티에 수정 로직 작성 x)을 지키면서 어떻게 처리하는 것이 좋을지 조언 부탁드립니다.
- Base Entity와 ApplyStatus enum 폴더 구조를 임의로 정했는데 확인 부탁드립니다.
- 약관 동의와 약관은 양방향 매핑이 불필요하다고 생각하는데 의견 부탁드립니다.