### PR TITLE
Feature/의상 승인 게시판 글 승인

### DIFF
--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/controller/CostumeApprovalBoardController.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/controller/CostumeApprovalBoardController.java
@@ -170,4 +170,26 @@ public class CostumeApprovalBoardController {
             .status(HttpStatus.OK)
             .build();
     }
+
+    /**
+     * [회사] 의상 승인 글 승인하기
+     *
+     * @param userDetails
+     * @param costumeApprovalBoardId
+     * @return
+     */
+    @PutMapping("/{costume_approval_board_id}/companies")
+    public ResponseEntity<?> updateCostumeApprovalBoardByCompany(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable(name = "costume_approval_board_id") Long costumeApprovalBoardId
+    ) {
+        costumeApprovalBoardService.updateCostumeApprovalBoardByCompany(
+            userDetails.getCompany(),
+            costumeApprovalBoardId
+        );
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .build();
+
+    }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/controller/CostumeApprovalBoardController.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/controller/CostumeApprovalBoardController.java
@@ -1,7 +1,9 @@
 package com.example.extra.domain.costumeapprovalboard.controller;
 
+import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardApplyStatusUpdateControllerRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardExplainCreateRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardExplainUpdateControllerRequestDto;
+import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardApplyStatusUpdateServiceRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadDetailServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCreateServiceDto;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -181,12 +184,19 @@ public class CostumeApprovalBoardController {
     @PutMapping("/{costume_approval_board_id}/companies")
     public ResponseEntity<?> updateCostumeApprovalBoardByCompany(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PathVariable(name = "costume_approval_board_id") Long costumeApprovalBoardId
+        @PathVariable(name = "costume_approval_board_id") Long costumeApprovalBoardId,
+        @RequestBody CostumeApprovalBoardApplyStatusUpdateControllerRequestDto controllerRequestDto
     ) {
+        CostumeApprovalBoardApplyStatusUpdateServiceRequestDto serviceRequestDto =
+            costumeApprovalBoardDtoMapper.toCostumeApprovalBoardApplyStatusUpdateServiceRequestDto(
+                controllerRequestDto);
+
         costumeApprovalBoardService.updateCostumeApprovalBoardByCompany(
             userDetails.getCompany(),
-            costumeApprovalBoardId
+            costumeApprovalBoardId,
+            serviceRequestDto
         );
+
         return ResponseEntity
             .status(HttpStatus.OK)
             .build();

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/controller/CostumeApprovalBoardApplyStatusUpdateControllerRequestDto.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/controller/CostumeApprovalBoardApplyStatusUpdateControllerRequestDto.java
@@ -1,0 +1,7 @@
+package com.example.extra.domain.costumeapprovalboard.dto.controller;
+
+public record CostumeApprovalBoardApplyStatusUpdateControllerRequestDto(
+    String costumeApprove
+) {
+
+}

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardApplyStatusUpdateServiceRequestDto.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardApplyStatusUpdateServiceRequestDto.java
@@ -1,0 +1,7 @@
+package com.example.extra.domain.costumeapprovalboard.dto.service;
+
+public record CostumeApprovalBoardApplyStatusUpdateServiceRequestDto(
+    String costumeApprove
+) {
+
+}

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardCompanyReadDetailServiceResponseDto.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardCompanyReadDetailServiceResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.extra.domain.costumeapprovalboard.dto.service;
 
 import com.example.extra.domain.costumeapprovalboard.entity.CostumeApprovalBoard;
+import com.example.extra.global.enums.ApplyStatus;
 import lombok.Builder;
 
 @Builder
@@ -12,18 +13,20 @@ public record CostumeApprovalBoardCompanyReadDetailServiceResponseDto(
     String costume,
     String image_explain,
     String image_url,
-    Boolean costume_approve
+    ApplyStatus costume_approve
 ) {
-    public static CostumeApprovalBoardCompanyReadDetailServiceResponseDto from(CostumeApprovalBoard costumeApprovalBoard) {
+
+    public static CostumeApprovalBoardCompanyReadDetailServiceResponseDto from(
+        CostumeApprovalBoard costumeApprovalBoard) {
         return CostumeApprovalBoardCompanyReadDetailServiceResponseDto
             .builder()
-                .id(costumeApprovalBoard.getId())
-                .member_name(costumeApprovalBoard.getMember().getName())
-                .role_name(costumeApprovalBoard.getRole().getRole_name())
-                .sex(costumeApprovalBoard.getRole().getSex())
-                .costume(costumeApprovalBoard.getRole().getCostume())
-                .image_explain(costumeApprovalBoard.getImage_explain())
-                .costume_approve(costumeApprovalBoard.getCostume_approve())
+            .id(costumeApprovalBoard.getId())
+            .member_name(costumeApprovalBoard.getMember().getName())
+            .role_name(costumeApprovalBoard.getRole().getRole_name())
+            .sex(costumeApprovalBoard.getRole().getSex())
+            .costume(costumeApprovalBoard.getRole().getCostume())
+            .image_explain(costumeApprovalBoard.getImage_explain())
+            .costume_approve(costumeApprovalBoard.getCostume_approve())
             .build();
     }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardCompanyReadServiceResponseDto.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardCompanyReadServiceResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.extra.domain.costumeapprovalboard.dto.service;
 
 import com.example.extra.domain.costumeapprovalboard.entity.CostumeApprovalBoard;
+import com.example.extra.global.enums.ApplyStatus;
 import lombok.Builder;
 
 @Builder
@@ -8,15 +9,17 @@ public record CostumeApprovalBoardCompanyReadServiceResponseDto(
     Long id,
     String member_name,
     String role_name,
-    Boolean costume_approve
+    ApplyStatus costume_approve
 ) {
-    public static CostumeApprovalBoardCompanyReadServiceResponseDto from(CostumeApprovalBoard costumeApprovalBoard) {
+
+    public static CostumeApprovalBoardCompanyReadServiceResponseDto from(
+        CostumeApprovalBoard costumeApprovalBoard) {
         return CostumeApprovalBoardCompanyReadServiceResponseDto
             .builder()
-                .id(costumeApprovalBoard.getId())
-                .member_name(costumeApprovalBoard.getMember().getName())
-                .role_name(costumeApprovalBoard.getRole().getRole_name())
-                .costume_approve(costumeApprovalBoard.getCostume_approve())
+            .id(costumeApprovalBoard.getId())
+            .member_name(costumeApprovalBoard.getMember().getName())
+            .role_name(costumeApprovalBoard.getRole().getRole_name())
+            .costume_approve(costumeApprovalBoard.getCostume_approve())
             .build();
     }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardMemberReadServiceResponseDto.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/dto/service/CostumeApprovalBoardMemberReadServiceResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.extra.domain.costumeapprovalboard.dto.service;
 
 import com.example.extra.domain.costumeapprovalboard.entity.CostumeApprovalBoard;
+import com.example.extra.global.enums.ApplyStatus;
 import lombok.Builder;
 
 @Builder
@@ -11,18 +12,20 @@ public record CostumeApprovalBoardMemberReadServiceResponseDto(
     String costume,
     String image_explain,
     String image_url,
-    Boolean costume_approve
+    ApplyStatus costume_approve
 ) {
-    public static CostumeApprovalBoardMemberReadServiceResponseDto from(CostumeApprovalBoard costumeApprovalBoard) {
+
+    public static CostumeApprovalBoardMemberReadServiceResponseDto from(
+        CostumeApprovalBoard costumeApprovalBoard) {
         return CostumeApprovalBoardMemberReadServiceResponseDto
             .builder()
-                .id(costumeApprovalBoard.getId())
-                .role_name(costumeApprovalBoard.getRole().getRole_name())
-                .sex(costumeApprovalBoard.getRole().getSex())
-                .costume(costumeApprovalBoard.getRole().getCostume())
-                .image_explain(costumeApprovalBoard.getImage_explain())
-                .image_url(costumeApprovalBoard.getCostume_image_url())
-                .costume_approve(costumeApprovalBoard.getCostume_approve())
+            .id(costumeApprovalBoard.getId())
+            .role_name(costumeApprovalBoard.getRole().getRole_name())
+            .sex(costumeApprovalBoard.getRole().getSex())
+            .costume(costumeApprovalBoard.getRole().getCostume())
+            .image_explain(costumeApprovalBoard.getImage_explain())
+            .image_url(costumeApprovalBoard.getCostume_image_url())
+            .costume_approve(costumeApprovalBoard.getCostume_approve())
             .build();
     }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -72,4 +72,8 @@ public class CostumeApprovalBoard extends BaseEntity {
     public void updateCostumeImageUrl(String costumeImageUrl) {
         this.costume_image_url = costumeImageUrl;
     }
+
+    public void updateCostumeApprove() {
+        this.costume_approve = true;
+    }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -3,6 +3,7 @@ package com.example.extra.domain.costumeapprovalboard.entity;
 import com.example.extra.domain.member.entity.Member;
 import com.example.extra.domain.role.entity.Role;
 import com.example.extra.global.entity.BaseEntity;
+import com.example.extra.global.enums.ApplyStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -33,8 +34,8 @@ public class CostumeApprovalBoard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "boolean default false")
-    private Boolean costume_approve;
+    @Column
+    private ApplyStatus costume_approve;
 
     @Column
     private String costume_image_url;
@@ -52,13 +53,12 @@ public class CostumeApprovalBoard extends BaseEntity {
 
     @Builder
     public CostumeApprovalBoard(
-        final Boolean costumeApprove,
         final String costumeImageUrl,
         final String imageExplain,
         final Member member,
         final Role role
     ) {
-        this.costume_approve = costumeApprove;
+        this.costume_approve = ApplyStatus.APPLIED;
         this.costume_image_url = costumeImageUrl;
         this.image_explain = imageExplain;
         this.member = member;
@@ -73,7 +73,7 @@ public class CostumeApprovalBoard extends BaseEntity {
         this.costume_image_url = costumeImageUrl;
     }
 
-    public void updateCostumeApprove() {
-        this.costume_approve = true;
+    public void updateCostumeApprove(ApplyStatus applyStatus) {
+        this.costume_approve = applyStatus;
     }
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/exception/CostumeApprovalBoardErrorCode.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/exception/CostumeApprovalBoardErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum CostumeApprovalBoardErrorCode implements ErrorCode {
     // 400
     ALREADY_EXIST_COSTUME_APPROVAL_BOARD(HttpStatus.BAD_REQUEST, "이미 글을 작성했습니다."),
+    ALREADY_APPROVED(HttpStatus.BAD_REQUEST, "이미 승인된 글입니다."),
     NOT_MASTER_COSTUME_APPROVAL_BOARD(HttpStatus.BAD_REQUEST, "회원이 작성한 글이 아닙니다."),
     NOT_ABLE_TO_ACCESS_COSTUME_APPROVAL_BOARD(HttpStatus.BAD_REQUEST, "해당 공고에 대한 권한이 없습니다"),
     NOT_ABLE_TO_READ_COSTUME_APPROVAL_BOARD(HttpStatus.BAD_REQUEST, "해당 글을 읽을 권한이 없습니다"),

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/mapper/dto/CostumeApprovalBoardDtoMapper.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/mapper/dto/CostumeApprovalBoardDtoMapper.java
@@ -2,8 +2,10 @@ package com.example.extra.domain.costumeapprovalboard.mapper.dto;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
+import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardApplyStatusUpdateControllerRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardExplainCreateRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.controller.CostumeApprovalBoardExplainUpdateControllerRequestDto;
+import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardApplyStatusUpdateServiceRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCreateServiceDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardExplainUpdateServiceRequestDto;
 import org.mapstruct.Mapper;
@@ -20,6 +22,10 @@ public interface CostumeApprovalBoardDtoMapper {
     CostumeApprovalBoardExplainUpdateServiceRequestDto toCostumeApprovalBoardExplainUpdateServiceRequestDto(
         CostumeApprovalBoardExplainUpdateControllerRequestDto costumeApprovalBoardExplainUpdateControllerRequestDto,
         MultipartFile multipartFile
+    );
+
+    CostumeApprovalBoardApplyStatusUpdateServiceRequestDto toCostumeApprovalBoardApplyStatusUpdateServiceRequestDto(
+        CostumeApprovalBoardApplyStatusUpdateControllerRequestDto costumeApprovalBoardApplyStatusUpdateControllerRequestDto
     );
 }
 

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/service/CostumeApprovalBoardService.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/service/CostumeApprovalBoardService.java
@@ -47,4 +47,9 @@ public interface CostumeApprovalBoardService {
         final Member member,
         final CostumeApprovalBoardExplainUpdateServiceRequestDto serviceRequestDto
     );
+
+    void updateCostumeApprovalBoardByCompany(
+        Company company,
+        Long costumeApprovalBoardId
+    );
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/service/CostumeApprovalBoardService.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/service/CostumeApprovalBoardService.java
@@ -1,6 +1,7 @@
 package com.example.extra.domain.costumeapprovalboard.service;
 
 import com.example.extra.domain.company.entity.Company;
+import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardApplyStatusUpdateServiceRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadDetailServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCreateServiceDto;
@@ -49,7 +50,8 @@ public interface CostumeApprovalBoardService {
     );
 
     void updateCostumeApprovalBoardByCompany(
-        Company company,
-        Long costumeApprovalBoardId
+        final Company company,
+        final Long costumeApprovalBoardId,
+        final CostumeApprovalBoardApplyStatusUpdateServiceRequestDto controllerRequestDto
     );
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/service/impl/CostumeApprovalBoardServiceImpl.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/service/impl/CostumeApprovalBoardServiceImpl.java
@@ -216,6 +216,32 @@ public class CostumeApprovalBoardServiceImpl implements CostumeApprovalBoardServ
         }
     }
 
+    public void updateCostumeApprovalBoardByCompany(
+        Company company,
+        Long costumeApprovalBoardId
+    ) {
+        // costume approval board가 있는지 확인
+        CostumeApprovalBoard costumeApprovalBoard = costumeApprovalBoardRepository.findById(
+                costumeApprovalBoardId).
+            orElseThrow(() -> new CostumeApprovalBoardException(
+                CostumeApprovalBoardErrorCode.NOT_FOUND_COSTUME_APPROVAL_BOARD));
+
+        // company가 작성한 job post의 role인지 확인
+        if (!company.getId().equals(
+            costumeApprovalBoard
+                .getRole()
+                .getJobPost()
+                .getCompany()
+                .getId())
+        ) {
+            throw new CostumeApprovalBoardException(
+                CostumeApprovalBoardErrorCode.NOT_ABLE_TO_ACCESS_COSTUME_APPROVAL_BOARD);
+        }
+
+        // 승인 여부 변경
+        costumeApprovalBoard.updateCostumeApprove();
+    }
+
     /**
      * 지원 요청 여부 확인 후, 지원 상태 가져오기
      *

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/service/impl/CostumeApprovalBoardServiceImpl.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/service/impl/CostumeApprovalBoardServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.extra.domain.applicationrequest.exception.ApplicationRequestE
 import com.example.extra.domain.applicationrequest.repository.ApplicationRequestCompanyRepository;
 import com.example.extra.domain.applicationrequest.repository.ApplicationRequestMemberRepository;
 import com.example.extra.domain.company.entity.Company;
+import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardApplyStatusUpdateServiceRequestDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadDetailServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCompanyReadServiceResponseDto;
 import com.example.extra.domain.costumeapprovalboard.dto.service.CostumeApprovalBoardCreateServiceDto;
@@ -172,7 +173,6 @@ public class CostumeApprovalBoardServiceImpl implements CostumeApprovalBoardServ
 
         // 의상 승인 게시판 생성하기
         CostumeApprovalBoard costumeApprovalBoard = CostumeApprovalBoard.builder()
-            .costumeApprove(false)
             .costumeImageUrl(costumeImageUrl)
             .member(member)
             .role(role)
@@ -216,9 +216,12 @@ public class CostumeApprovalBoardServiceImpl implements CostumeApprovalBoardServ
         }
     }
 
+    @Override
+    @Transactional
     public void updateCostumeApprovalBoardByCompany(
         Company company,
-        Long costumeApprovalBoardId
+        Long costumeApprovalBoardId,
+        CostumeApprovalBoardApplyStatusUpdateServiceRequestDto serviceRequestDto
     ) {
         // costume approval board가 있는지 확인
         CostumeApprovalBoard costumeApprovalBoard = costumeApprovalBoardRepository.findById(
@@ -238,8 +241,13 @@ public class CostumeApprovalBoardServiceImpl implements CostumeApprovalBoardServ
                 CostumeApprovalBoardErrorCode.NOT_ABLE_TO_ACCESS_COSTUME_APPROVAL_BOARD);
         }
 
-        // 승인 여부 변경
-        costumeApprovalBoard.updateCostumeApprove();
+        // 승인 여부 확인 및 변경
+        if (costumeApprovalBoard.getCostume_approve() == ApplyStatus.APPROVED) {
+            throw new CostumeApprovalBoardException(CostumeApprovalBoardErrorCode.ALREADY_APPROVED);
+        }
+        costumeApprovalBoard.updateCostumeApprove(
+            ApplyStatus.fromString(serviceRequestDto.costumeApprove())
+        );
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) `#이슈번호, #이슈번호`</br>
> 해당 PR이 닫힐 때, 이슈도 닫히게 하고싶다면? ex) `close #이슈번호, #이슈번호`

- #68 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 의상 승인 게시판 글 승인 여부 수정 로직 작성
- [x] 테스트
  - [x] 성공 - 대기 -> 승인
  - [x] 성공 - 대기 -> 거부
  - [x] 성공 - 거부 -> 승인
  - [x] 실패 - 400 접근 권한 없는 의상 글
  - [x] 실패 - 400 이미 승인된 글
  - [x] 실패 - 404 승인 게시글 없음 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 현재는 승인 여부를 거부 -> 승인으로 변경하는 것만 생각하고 로직을 작성했는데요.
- 승인 전 / 승인 거부 / 승인 완료 이 3가지를 구분하는 게 더 좋을 것 같다는 피드백을 받아서 이 부분 생각 중입니다.
  - costume approve enum으로 변경
  - update 할 때 request body로 승인 종류 받기
  - 승인된 경우에는 수정 불가능
