### PR TITLE
Feature/카카오 가입자 로그인 처리

### DIFF
--- a/src/main/java/com/example/extra/global/security/oauth/controller/KakaoController.java
+++ b/src/main/java/com/example/extra/global/security/oauth/controller/KakaoController.java
@@ -2,6 +2,7 @@ package com.example.extra.global.security.oauth.controller;
 
 import com.example.extra.global.security.oauth.dto.controller.KakaoLoginControllerRequestDto;
 import com.example.extra.global.security.oauth.dto.service.request.KakaoLoginServiceRequestDto;
+import com.example.extra.global.security.oauth.dto.service.response.KakaoLoginCheckServiceResponseDto;
 import com.example.extra.global.security.oauth.dto.service.response.KakaoLoginServiceResponseDto;
 import com.example.extra.global.security.oauth.dto.service.response.KakaoTokenInfoServiceResponseDto;
 import com.example.extra.global.security.oauth.entity.KakaoInfo;
@@ -51,8 +52,12 @@ public class KakaoController {
         String accessToken = tokenInfoServiceResponseDto.accessToken();
 
         KakaoInfo kakaoInfo = null;
+        boolean isSignup = false;
         try {
-            kakaoInfo = oauthKakaoService.getKakaoInfo(accessToken);
+            KakaoLoginCheckServiceResponseDto loginCheckServiceResponseDto =
+                oauthKakaoService.getKakaoInfo(accessToken);
+            kakaoInfo = loginCheckServiceResponseDto.kakaoInfo();
+            isSignup = loginCheckServiceResponseDto.isSignup();
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -66,7 +71,10 @@ public class KakaoController {
             .userRole(controllerRequestDto.userRole())
             .build();
 
-        KakaoLoginServiceResponseDto loginServiceResponseDto =
+        // 회원 가입을 한 경우 -> login
+        // 회원 가입을 하지 않은 경우 -> signup
+        KakaoLoginServiceResponseDto loginServiceResponseDto = isSignup ?
+            oauthKakaoService.login(loginServiceRequestDto) :
             oauthKakaoService.signup(loginServiceRequestDto);
 
         return ResponseEntity

--- a/src/main/java/com/example/extra/global/security/oauth/dto/service/response/KakaoLoginCheckServiceResponseDto.java
+++ b/src/main/java/com/example/extra/global/security/oauth/dto/service/response/KakaoLoginCheckServiceResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.extra.global.security.oauth.dto.service.response;
+
+import com.example.extra.global.security.oauth.entity.KakaoInfo;
+
+public record KakaoLoginCheckServiceResponseDto(
+    KakaoInfo kakaoInfo,
+    boolean isSignup
+) {
+
+}

--- a/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
@@ -93,11 +93,8 @@ public class KakaoServiceImpl {
     }
 
     // 중복 확인
-    private void validate(final String email) {
-        accountRepository.findByEmail(email)
-            .ifPresent(m -> {
-                throw new AccountException(AccountErrorCode.DUPLICATION_ACCOUNT);
-            });
+    private boolean checkSignup(final String email) {
+        return accountRepository.findByEmail(email).isPresent();
     }
 
     public KakaoInfo getKakaoInfo(String accessToken)

--- a/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
@@ -36,7 +37,9 @@ public class KakaoServiceImpl {
 
     private final AccountRepository accountRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+
     private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${kakao.client.id}")
     String clientId;
@@ -152,13 +155,14 @@ public class KakaoServiceImpl {
     public KakaoLoginServiceResponseDto signup(
         final KakaoLoginServiceRequestDto serviceRequestDto
     ) {
-        String uuid = UUID.randomUUID()
-            .toString()
-            .replace("-", "");
+        String password = passwordEncoder.encode(
+            UUID.randomUUID()
+                .toString()
+                .replace("-", ""));
 
         Account account = Account.builder()
             .email(serviceRequestDto.email())
-            .password(uuid)
+            .password(password)
             .userRole(serviceRequestDto.userRole())
             .build();
 

--- a/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/extra/global/security/oauth/service/KakaoServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.extra.domain.refreshtoken.repository.RefreshTokenRepository;
 import com.example.extra.domain.refreshtoken.token.RefreshToken;
 import com.example.extra.global.security.JwtUtil;
 import com.example.extra.global.security.oauth.dto.service.request.KakaoLoginServiceRequestDto;
+import com.example.extra.global.security.oauth.dto.service.response.KakaoLoginCheckServiceResponseDto;
 import com.example.extra.global.security.oauth.dto.service.response.KakaoLoginServiceResponseDto;
 import com.example.extra.global.security.oauth.dto.service.response.KakaoTokenInfoServiceResponseDto;
 import com.example.extra.global.security.oauth.entity.KakaoInfo;
@@ -97,7 +98,7 @@ public class KakaoServiceImpl {
         return accountRepository.findByEmail(email).isPresent();
     }
 
-    public KakaoInfo getKakaoInfo(String accessToken)
+    public KakaoLoginCheckServiceResponseDto getKakaoInfo(String accessToken)
         throws JsonProcessingException {
         // HTTP Header
         HttpHeaders headers = new HttpHeaders();
@@ -139,18 +140,18 @@ public class KakaoServiceImpl {
 //            .asText();
 
         KakaoInfo kakaoInfo = new KakaoInfo(id, email);
-        validate(kakaoInfo.getId().toString());
+        boolean isSignup = checkSignup(kakaoInfo.getId().toString());
 
-        return kakaoInfo;
+        return new KakaoLoginCheckServiceResponseDto(
+            kakaoInfo,
+            isSignup
+        );
     }
 
     @Transactional
     public KakaoLoginServiceResponseDto signup(
         final KakaoLoginServiceRequestDto serviceRequestDto
     ) {
-        String email = serviceRequestDto.email();
-        validate(email);
-
         String uuid = UUID.randomUUID()
             .toString()
             .replace("-", "");


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) `#이슈번호, #이슈번호`</br>
> 해당 PR이 닫힐 때, 이슈도 닫히게 하고싶다면? ex) `close #이슈번호, #이슈번호`

- #107 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원 가입 여부 확인해서 로직 달리하기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

### flow

1. 아래 url로 요청 (authorize)
    
    ```bash
    http://localhost:8080/api/v1/oauth/authorize
    
    ```
    
2. request body의 redirect 뒤의 url으로 이동
    
    ```bash
    redirect:https://kauth.kakao.com/oauth/authorize?response_type=code&client_id={client_id}&redirect_uri={redirect_uri}
    
    ```
    
3. 회원 가입 후 받는 url에서 code 추출
    
    ```bash
    http://localhost:8080/api/v1/oauth/callback/kakao?code={code}
    ```
    
4. url 요청
    - request param : code
    - request body : user role { USER / COMPANY }
    
    ```bash
    http://localhost:8080/api/v1/oauth/kakao?code={code}
    ```
    
    - 반환값
        - resopnse body
        
        ```bash
        {
            "access_token":"${ACCESS_TOKEN}",
            "token_type":"bearer",
            "refresh_token":"${REFRESH_TOKEN}",
            "refresh_token_expires_in":5184000,
            "expires_in":43199,
        }
        ```
        
        - response header에 authorization 토큰으로 인증 진행