### PR TITLE
Refactor/define db schema

### DIFF
--- a/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequest.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/entity/ApplicationRequest.java
@@ -15,6 +15,8 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,10 +30,12 @@ public abstract class ApplicationRequest extends BaseEntity {
     protected ApplyStatus applyStatus;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = false)
     protected Member member;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "role_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "role_id", nullable = false)
     protected Role role;
 }

--- a/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
+++ b/src/main/java/com/example/extra/domain/attendancemanagement/entity/AttendanceManagement.java
@@ -17,7 +17,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,19 +29,23 @@ public class AttendanceManagement extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDateTime clockInTime;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime clockInTime; // nullable
 
-    private LocalDateTime clockOutTime;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime clockOutTime; // nullable
 
-    @ColumnDefault("0")
+    @Column(columnDefinition = "SMALLINT UNSIGNED not null")
     private Integer mealCount;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "job_post_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "job_post_id", nullable = false)
     private JobPost jobPost;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @Builder

--- a/src/main/java/com/example/extra/domain/company/controller/CompanyController.java
+++ b/src/main/java/com/example/extra/domain/company/controller/CompanyController.java
@@ -27,9 +27,6 @@ public class CompanyController {
     private final CompanyService companyService;
     private final CompanyDtoMapper companyDtoMapper;
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-
-
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
         @Valid @RequestBody CompanyCreateControllerRequestDto controllerRequestDto

--- a/src/main/java/com/example/extra/domain/company/entity/Company.java
+++ b/src/main/java/com/example/extra/domain/company/entity/Company.java
@@ -10,16 +10,20 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,24 +35,17 @@ public class Company extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
+    @Column(nullable = false)
+    @Size(max = 30)
     private String name;
 
-    @Column
-    private String companyUrl;
+    @Column // varchar(255)
+    private String companyUrl; // nullable(아직 프론트에서 안받음)
 
-    @OneToOne(
-        optional = false,
-        fetch = FetchType.LAZY
-    )
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "account_id", nullable = false)
     private Account account;
-
-    // TODO - 회사-공고글 양방향 매핑할 지 확인 받기 + cascade 정책 확인 받기
-    @OneToMany(mappedBy = "company", cascade = CascadeType.ALL)
-    private List<JobPost> jobPostList = new ArrayList<>();
-
-    // TODO - 코드 컨벤션(엔티티에 수정 로직 작성x) 지키면서 어떻게 양방향 처리 할 수 있을지 확인하기.
-    // public void addJobPost(JobPost jobPost) {}
 
     @Builder
     public Company(
@@ -60,9 +57,4 @@ public class Company extends BaseEntity {
         this.companyUrl = companyUrl;
         this.account = account;
     }
-
-    public String tokenId() {
-        return this.id.toString() + "C";
-    }
-
 }

--- a/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
+++ b/src/main/java/com/example/extra/domain/costumeapprovalboard/entity/CostumeApprovalBoard.java
@@ -18,6 +18,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,24 +36,26 @@ public class CostumeApprovalBoard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false) // varchar(255)
     private ApplyStatus costumeApprove;
 
-    @Column
+    @Column(nullable = false) // varchar(255)
     private String costumeImageUrl;
 
-    @Column
+    @Column(nullable = false) // varchar(255)
     private String folderName;
 
-    @Column
+    @Column(nullable = false) // varchar(255)
     private String imageExplain;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "role_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "role_id", nullable = false)
     private Role role;
 
     @Builder

--- a/src/main/java/com/example/extra/domain/jobpost/dto/controller/JobPostUpdateControllerRequestDto.java
+++ b/src/main/java/com/example/extra/domain/jobpost/dto/controller/JobPostUpdateControllerRequestDto.java
@@ -1,12 +1,11 @@
 package com.example.extra.domain.jobpost.dto.controller;
 
 import com.example.extra.global.enums.Category;
-import java.time.LocalDateTime;
 
 public record JobPostUpdateControllerRequestDto(
     String title,
     String gatheringLocation,
-    LocalDateTime gatheringTime,
+    String gatheringTime,
     String imageUrl,
     Boolean status,
     Integer hourPay,

--- a/src/main/java/com/example/extra/domain/jobpost/entity/JobPost.java
+++ b/src/main/java/com/example/extra/domain/jobpost/entity/JobPost.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -35,19 +36,21 @@ public class JobPost extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false)
+    @Size(max = 30)
     private String title;
 
-    @Column
-    private String gatheringLocation;
+    @Column(nullable = false)
+    private String gatheringLocation; // varchar(255)
 
-    @Column
+    @Column(nullable = false)
+    @Size(max = 30)
     private String gatheringTime;
 
-    @Column
+    @Column(nullable = false)
     private Boolean status;
 
-    @Column
+    @Column(nullable = false)
     private Category category;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/member/entity/Member.java
+++ b/src/main/java/com/example/extra/domain/member/entity/Member.java
@@ -20,13 +20,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_MEMBER")
 @Entity
-@ToString
 public class Member extends BaseEntity {
 
     @Id
@@ -34,7 +34,7 @@ public class Member extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    @Size(min = 1, max = 10)
+    @Size(max = 10)
     private String name;
 
     @Column(nullable = false)
@@ -56,32 +56,31 @@ public class Member extends BaseEntity {
     @Size(max = 15)
     private String phone;
 
-    @Column
-    private String introduction;
+    @Column(columnDefinition = "TEXT")
+    private String introduction; // nullable
 
-    @Column
-    private String license;
+    @Column(columnDefinition = "TEXT")
+    private String license; // nullable
 
-    @Column
-    private String pros;
+    @Column(columnDefinition = "TEXT")
+    private String pros; // nullable
 
-    @Column
+    @Column(nullable = false)
     @Size(max = 10)
     private String bank;
 
-    @Column
+    @Column(nullable = false)
     @Size(max = 30)
     private String accountNumber;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "tattoo_id")
-    @ToString.Exclude
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "tattoo_id", nullable = false)
     private Tattoo tattoo;
 
-    @OneToOne(
-        optional = false,
-        fetch = FetchType.LAZY
-    )
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "account_id", nullable = false)
     private Account account;
 
 //    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
@@ -131,10 +130,6 @@ public class Member extends BaseEntity {
 
     public void updateTattoo(Tattoo tattoo) {
         this.tattoo = tattoo;
-    }
-
-    public String tokenId() {
-        return this.id.toString() + "M";
     }
 
     public void update(final MemberUpdateServiceRequestDto serviceRequestDto) {

--- a/src/main/java/com/example/extra/domain/memberterms/entity/MemberTerms.java
+++ b/src/main/java/com/example/extra/domain/memberterms/entity/MemberTerms.java
@@ -16,6 +16,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,11 +32,13 @@ public class MemberTerms extends BaseEntity {
     private Boolean agree;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "term_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "term_id", nullable = false)
     private Terms term;
 
     @Builder

--- a/src/main/java/com/example/extra/domain/role/entity/Role.java
+++ b/src/main/java/com/example/extra/domain/role/entity/Role.java
@@ -13,12 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -32,33 +32,35 @@ public class Role extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false)
+    @Size(max = 10)
     private String roleName;
 
-    @Column
+    @Column(nullable = false)
+    @Size(max = 50)
     private String costume;
 
-    @Column
+    @Column(nullable = false)
     private Boolean sex;
 
-    @Column
+    @Column(nullable = false)
     private LocalDate minAge;
 
-    @Column
+    @Column(nullable = false)
     private LocalDate maxAge;
 
-    @Column
+    @Column(columnDefinition = "SMALLINT UNSIGNED not null")
     private Integer limitPersonnel;
 
-    @Column
+    @Column(columnDefinition = "SMALLINT UNSIGNED not null")
     private Integer currentPersonnel;
 
-    @Column
+    @Column(nullable = false)
     private Season season;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "tattoo_id")
-    @ToString.Exclude
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "tattoo_id", nullable = false)
     private Tattoo tattoo;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/example/extra/domain/role/repository/RoleRepository.java
+++ b/src/main/java/com/example/extra/domain/role/repository/RoleRepository.java
@@ -1,6 +1,5 @@
 package com.example.extra.domain.role.repository;
 
-import com.example.extra.domain.company.entity.Company;
 import com.example.extra.domain.jobpost.entity.JobPost;
 import com.example.extra.domain.role.entity.Role;
 import java.util.List;

--- a/src/main/java/com/example/extra/domain/tattoo/entity/Tattoo.java
+++ b/src/main/java/com/example/extra/domain/tattoo/entity/Tattoo.java
@@ -10,13 +10,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "TB_TATTOO")
 @Entity
-@ToString
 public class Tattoo {
 
     @Id

--- a/src/main/java/com/example/extra/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/extra/global/entity/BaseEntity.java
@@ -3,8 +3,6 @@ package com.example.extra.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
 import java.time.LocalDateTime;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -13,13 +11,11 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseEntity {
-    @Column(nullable = false, updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
+    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
+    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false)
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- this closes #140 

## 📝작업 내용
<DB 스키마 관련>
- 외래키 포함된 엔티티에 대해 on delete cascade 적용
- string 타입 필드에 대해 column size 적용
- 정수 타입 변경(int -> small int unsigned : 65535까지)
   - 모집 인원, 현재 인원, 식사 횟수
- not null 제약조건 추가
   - 생성 시 프론트로부터 입력받는 부분은 다 not null 처리함.
- datetime 대신 timestamp 이용
   - 메모리 효율적이며 timezone 설정에 따라 다르게 표시될 수 있음
   - https://planetscale.com/blog/datetimes-vs-timestamps-in-mysql

<기타 리팩토링>
- 불필요한 import문 제거(일부)
- 잘못된 타입 변경
- 불필요한 변수 제거(일부)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
