### PR TITLE
Feature/fix attendance mangement exception

### DIFF
--- a/src/main/java/com/example/extra/domain/applicationrequest/controller/ApplicationRequestMemberController.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/controller/ApplicationRequestMemberController.java
@@ -147,10 +147,10 @@ public class ApplicationRequestMemberController {
     }
 
     // 요청 승인 및 거절(지원현황 화면)
-    @PutMapping("/company/application-requests/{applicationRequestId}")
+    @PutMapping("/company/application-requests/{applicationRequestMemberId}")
     public ResponseEntity<?> updateApplicationRequestMemberStatusToRejected(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @PathVariable(name = "applicationRequestId") Long applicationRequestId,
+        @PathVariable(name = "applicationRequestMemberId") Long applicationRequestMemberId,
         @Valid @RequestBody ApplicationRequestMemberUpdateControllerRequestDto controllerRequestDto
     ) {
         ApplicationRequestMemberUpdateServiceRequestDto serviceRequestDto =
@@ -159,15 +159,9 @@ public class ApplicationRequestMemberController {
             );
         applicationRequestMemberService.updateStatus(
             userDetails.getAccount(),
-            applicationRequestId,
+            applicationRequestMemberId,
             serviceRequestDto
         );
-        if (serviceRequestDto.applyStatus() == ApplyStatus.APPROVED) {
-            applicationRequestMemberService.createAttendanceManagementIfApproved(
-                applicationRequestId,
-                serviceRequestDto
-            );
-        }
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/example/extra/domain/applicationrequest/exception/ApplicationRequestErrorCode.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/exception/ApplicationRequestErrorCode.java
@@ -12,6 +12,7 @@ public enum ApplicationRequestErrorCode implements ErrorCode {
     NOT_ABLE_TO_CANCEL_IN_APPROVED(HttpStatus.BAD_REQUEST, "승인 상태에서는 지원 철회가 불가합니다."),
     NOT_ABLE_TO_APPLY_TO_JOB_POST(HttpStatus.BAD_REQUEST, "해당 공고는 마감되었습니다."),
     NOT_APPROVED_REQUEST(HttpStatus.BAD_REQUEST, "승인되지 않은 공고입니다."),
+    ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 해당 역할에 지원하였습니다."),
 
     // 403
     NOT_ABLE_TO_ACCESS_APPLICATION_REQUEST_MEMBER(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),

--- a/src/main/java/com/example/extra/domain/applicationrequest/service/ApplicationRequestMemberService.java
+++ b/src/main/java/com/example/extra/domain/applicationrequest/service/ApplicationRequestMemberService.java
@@ -46,11 +46,6 @@ public interface ApplicationRequestMemberService {
         final ApplicationRequestMemberUpdateServiceRequestDto applicationRequestMemberUpdateServiceRequestDto
     );
 
-    void createAttendanceManagementIfApproved(
-        final Long applicationRequestMemberId,
-        final ApplicationRequestMemberUpdateServiceRequestDto applicationRequestMemberUpdateServiceRequestDto
-    );
-
     MemberReadServiceResponseDto readOnceApplicationRequestMember(
         Account account,
         Long applicationRequestId

--- a/src/main/java/com/example/extra/domain/attendancemanagement/exception/AttendanceManagementErrorCode.java
+++ b/src/main/java/com/example/extra/domain/attendancemanagement/exception/AttendanceManagementErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AttendanceManagementErrorCode implements ErrorCode {
     ALREADY_CLOCKED_IN(HttpStatus.BAD_REQUEST, "이미 출근 처리가 완료되었습니다."),
     ALREADY_CLOCKED_OUT(HttpStatus.BAD_REQUEST, "이미 퇴근 처리가 완료되었습니다."),
+    ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 해당 공고에 지원 승인 되었습니다."),
 
     FORBIDDEN_ACCESS_ATTENDANCE_MANAGEMENT(HttpStatus.FORBIDDEN, "해당 촬영에 접근 권한이 없습니다. 해당 촬영의 공고를 작성한 계정으로 다시 시도하세요."),
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- this closes #144 

## 📝작업 내용
- 이미 승인한 출연자에 대해 다시 승인하려 할 시 예외 처리
- 지원 상태를 update하는 로직과 지원상태가 승인으로 바뀔 경우 attendance management 테이블에 create하는 로직 하나의 트랜잭션으로 묶음

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/705c6b85-66f9-4f23-ab71-4f0a59ab1431)


## 💬리뷰 요구사항(선택)
